### PR TITLE
Include metrics server install

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ No modules.
 | Name | Type |
 |------|------|
 | [helm_release.materialize_operator](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.metrics_server](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_job.db_init_job](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job) | resource |
 | [kubernetes_manifest.materialize_instances](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace.instance_namespaces](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.materialize](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_namespace.monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_secret.materialize_backends](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 
 ## Inputs
@@ -44,7 +46,10 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name | `string` | n/a | yes |
 | <a name="input_helm_repository"></a> [helm\_repository](#input\_helm\_repository) | Repository URL for the Materialize operator Helm chart | `string` | `"https://materializeinc.github.io/materialize/"` | no |
 | <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Values to pass to the Helm chart | `any` | n/a | yes |
+| <a name="input_install_metrics_server"></a> [install\_metrics\_server](#input\_install\_metrics\_server) | Whether to install the metrics-server | `bool` | `true` | no |
 | <a name="input_instances"></a> [instances](#input\_instances) | Configuration for Materialize instances | <pre>list(object({<br/>    name                 = string<br/>    namespace            = optional(string)<br/>    database_name        = string<br/>    metadata_backend_url = string<br/>    persist_backend_url  = string<br/>    environmentd_version = optional(string, "v0.130.1")<br/>    cpu_request          = optional(string, "1")<br/>    memory_request       = optional(string, "1Gi")<br/>    memory_limit         = optional(string, "1Gi")<br/>  }))</pre> | `[]` | no |
+| <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of metrics-server to install | `string` | `"3.12.2"` | no |
+| <a name="input_monitoring_namespace"></a> [monitoring\_namespace](#input\_monitoring\_namespace) | Namespace for monitoring resources | `string` | `"monitoring"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace prefix for all resources | `string` | n/a | yes |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | Namespace for the Materialize operator | `string` | `"materialize"` | no |
 | <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v25.1.0"` | no |

--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -1,5 +1,10 @@
 locals {
   default_helm_values = {
+    observability = {
+      podMetrics = {
+        enabled = true
+      }
+    }
     operator = {
       image = {
         tag = var.orchestratord_version

--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -50,6 +50,11 @@ module "operator" {
     image = {
       tag = var.orchestratord_version
     }
+    observability = {
+      podMetrics = {
+        enabled = true
+      }
+    }
     operator = {
       cloudProvider = {
         type   = "gcp"

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,24 @@ variable "operator_namespace" {
   default     = "materialize"
 }
 
+variable "monitoring_namespace" {
+  description = "Namespace for monitoring resources"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "metrics_server_version" {
+  description = "Version of metrics-server to install"
+  type        = string
+  default     = "3.12.2"
+}
+
+variable "install_metrics_server" {
+  description = "Whether to install the metrics-server"
+  type        = bool
+  default     = true
+}
+
 variable "instances" {
   description = "Configuration for Materialize instances"
   type = list(object({


### PR DESCRIPTION
As we discussed, currently without the metrics server, the Console would not display the Cluster utilization graphs.

Once this PR has been merged, we would need to cut a new release and update the GCP and AWS modules as well to make sure that we pass the observability args as well.