### PR TITLE
GHA to automate version bumps in dependent repos

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,46 @@
+name: Bump Module Version in Dependent Repos
+
+on:
+ push:
+   tags:
+     - 'v*'
+
+jobs:
+ update-version:
+   runs-on: ubuntu-latest
+   strategy:
+     matrix:
+       repo: ['terraform-aws-materialize', 'terraform-azurerm-materialize', 'terraform-google-materialize']
+
+   steps:
+     - name: Get the version
+       id: get_version
+       run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+     - name: Checkout dependent repository
+       uses: actions/checkout@v4
+       with:
+         repository: MaterializeInc/${{ matrix.repo }}
+         token: ${{ secrets.GH_PAT }}
+
+     - name: Update version reference
+       run: |
+         sed -i 's|github.com/MaterializeInc/terraform-helm-materialize?ref=v[0-9.]*|github.com/MaterializeInc/terraform-helm-materialize?ref=${{ steps.get_version.outputs.VERSION }}|' main.tf
+
+     - name: Create Pull Request
+       uses: peter-evans/create-pull-request@v6
+       with:
+         token: ${{ secrets.GH_PAT }}
+         branch: update-helm-module-${{ steps.get_version.outputs.VERSION }}
+         title: "chore: Update terraform-helm-materialize to ${{ steps.get_version.outputs.VERSION }}"
+         body: |
+           Updates terraform-helm-materialize module to version ${{ steps.get_version.outputs.VERSION }}.
+
+           This PR was automatically generated.
+         commit-message: "chore: bump terraform-helm-materialize to ${{ steps.get_version.outputs.VERSION }}"
+         committer: GitHub <noreply@github.com>
+         author: GitHub <noreply@github.com>
+         labels: dependencies
+         base: main
+         delete-branch: true
+         signoff: true


### PR DESCRIPTION
At the moment whenever we bump the Helm Terraform module version, we have to manually bump the version in all dependant repositories, eg:

- https://github.com/MaterializeInc/terraform-azurerm-materialize/pull/15
- https://github.com/MaterializeInc/terraform-google-materialize/pull/20
- https://github.com/MaterializeInc/terraform-aws-materialize/pull/36

This GH action should help us automate this process whenever a new tag is pushed. 

The action requires a PAT, so open to suggestions on what the best way to add this would be! cc @jasonhernandez 

Fixes #15 