### PR TITLE
allow force drop of metadata db

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,9 @@ variable "postgres_version" {
   type        = string
   default     = "15"
 }
+
+variable "metadata_database_force_recreate" {
+  description = "Force recreation of the PG database on changes. This should only be turned on during development"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Allow forced recreation of the metadata database... this must cause forced recreation of the environment CRD
This should be doable with a lifecycle replace triggered by with each.key on the db init, but it seems to crash. 
We should not merge this until replacement is figured out. 