### PR TITLE
Update .terraform.lock.hcl when bumping Cloud module versions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,46 +1,51 @@
 name: Bump Module Version in Dependent Repos
 
 on:
- push:
-   tags:
-     - 'v*'
+  push:
+    tags:
+      - "v*"
 
 jobs:
- update-version:
-   runs-on: ubuntu-latest
-   strategy:
-     matrix:
-       repo: ['terraform-aws-materialize', 'terraform-azurerm-materialize', 'terraform-google-materialize']
+  update-version:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo:
+          [
+            "terraform-aws-materialize",
+            "terraform-azurerm-materialize",
+            "terraform-google-materialize",
+          ]
 
-   steps:
-     - name: Get the version
-       id: get_version
-       run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-     - name: Checkout dependent repository
-       uses: actions/checkout@v4
-       with:
-         repository: MaterializeInc/${{ matrix.repo }}
-         token: ${{ secrets.GH_PAT }}
+      - name: Checkout dependent repository
+        uses: actions/checkout@v4
+        with:
+          repository: MaterializeInc/${{ matrix.repo }}
+          token: ${{ secrets.GH_PAT }}
 
-     - name: Update version reference
-       run: |
-         sed -i 's|github.com/MaterializeInc/terraform-helm-materialize?ref=v[0-9.]*|github.com/MaterializeInc/terraform-helm-materialize?ref=${{ steps.get_version.outputs.VERSION }}|' main.tf
+      - name: Update version reference
+        run: |
+          sed -i 's|github.com/MaterializeInc/terraform-helm-materialize?ref=v[0-9.]*|github.com/MaterializeInc/terraform-helm-materialize?ref=${{ steps.get_version.outputs.VERSION }}|' main.tf
 
-     - name: Create Pull Request
-       uses: peter-evans/create-pull-request@v6
-       with:
-         token: ${{ secrets.GH_PAT }}
-         branch: update-helm-module-${{ steps.get_version.outputs.VERSION }}
-         title: "chore: Update terraform-helm-materialize to ${{ steps.get_version.outputs.VERSION }}"
-         body: |
-           Updates terraform-helm-materialize module to version ${{ steps.get_version.outputs.VERSION }}.
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
+          branch: update-helm-module-${{ steps.get_version.outputs.VERSION }}
+          title: "chore: Update terraform-helm-materialize to ${{ steps.get_version.outputs.VERSION }}"
+          body: |
+            Updates terraform-helm-materialize module to version ${{ steps.get_version.outputs.VERSION }}.
 
-           This PR was automatically generated.
-         commit-message: "chore: bump terraform-helm-materialize to ${{ steps.get_version.outputs.VERSION }}"
-         committer: GitHub <noreply@github.com>
-         author: GitHub <noreply@github.com>
-         labels: dependencies
-         base: main
-         delete-branch: true
-         signoff: true
+            This PR was automatically generated.
+          commit-message: "chore: bump terraform-helm-materialize to ${{ steps.get_version.outputs.VERSION }}"
+          committer: GitHub <noreply@github.com>
+          author: GitHub <noreply@github.com>
+          labels: dependencies
+          base: main
+          delete-branch: true
+          signoff: true

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -32,6 +32,23 @@ jobs:
         run: |
           sed -i 's|github.com/MaterializeInc/terraform-helm-materialize?ref=v[0-9.]*|github.com/MaterializeInc/terraform-helm-materialize?ref=${{ steps.get_version.outputs.VERSION }}|' main.tf
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.0"
+          terraform_wrapper: false
+
+      - name: Update .terraform.lock.hcl
+        run: |
+          # Initialize Terraform to update the lock file
+          terraform init -upgrade
+
+          # If lock file doesn't exist yet (unlikely but possible)
+          if [ ! -f .terraform.lock.hcl ]; then
+            echo "No lock file found. Creating it with terraform init."
+            terraform init
+          fi
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
@@ -41,7 +58,7 @@ jobs:
           body: |
             Updates terraform-helm-materialize module to version ${{ steps.get_version.outputs.VERSION }}.
 
-            This PR was automatically generated.
+            This PR was automatically generated and includes updated .terraform.lock.hcl file.
           commit-message: "chore: bump terraform-helm-materialize to ${{ steps.get_version.outputs.VERSION }}"
           committer: GitHub <noreply@github.com>
           author: GitHub <noreply@github.com>


### PR DESCRIPTION
Extend the version bump workflow to update both main.tf references and .terraform.lock.hcl files. This prevents dependency conflicts and the lock files remain in sync with the latest module version.