### PR TITLE
Wait for Materialize to have a status, and output resource IDs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,10 @@ output "materialize_instances" {
     }
   }
 }
+
+output "materialize_instance_resource_ids" {
+  description = "Resource IDs of created Materialize instances"
+  value = {
+    for name, instance in data.kubernetes_resource.materialize_instances : name => instance.object.status.resourceId
+  }
+}


### PR DESCRIPTION
Wait for Materialize to have a status, and output resource IDs. Terraform intentionally does not include the status in the `resource`, so we have to use a `data` object to get that. We also have to wait on the `resource`, since `data` objects can't wait.

This is needed for later computing the names of services in TargetGroupBindings for exposing those services with an NLB.