### PR TITLE
Bump terraform version in CI

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "~1.0"
+          terraform_version: "1.9.8"
           terraform_wrapper: false
 
       - name: Update .terraform.lock.hcl

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.7.0"
+          terraform_version: "1.9.8"
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive


### PR DESCRIPTION
This should fix the last bump CI failure:

https://github.com/MaterializeInc/terraform-helm-materialize/actions/runs/13792788749/job/38576790213