### PR TITLE
Add OpenEBS install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,15 @@ No modules.
 |------|------|
 | [helm_release.materialize_operator](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.metrics_server](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.openebs](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_job.db_init_job](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job) | resource |
 | [kubernetes_manifest.materialize_instances](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace.instance_namespaces](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.materialize](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_namespace.openebs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_secret.materialize_backends](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_resource.materialize_instances](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/resource) | data source |
 
 ## Inputs
 
@@ -69,10 +72,13 @@ No modules.
 | <a name="input_helm_repository"></a> [helm\_repository](#input\_helm\_repository) | Repository URL for the Materialize operator Helm chart. Leave empty if using local chart. | `string` | `"https://materializeinc.github.io/materialize/"` | no |
 | <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Values to pass to the Helm chart | `any` | n/a | yes |
 | <a name="input_install_metrics_server"></a> [install\_metrics\_server](#input\_install\_metrics\_server) | Whether to install the metrics-server | `bool` | `true` | no |
-| <a name="input_instances"></a> [instances](#input\_instances) | Configuration for Materialize instances | <pre>list(object({<br/>    name                    = string<br/>    namespace               = optional(string)<br/>    create_database         = optional(bool, true)<br/>    database_name           = string<br/>    metadata_backend_url    = string<br/>    persist_backend_url     = string<br/>    environmentd_version    = optional(string, "v0.130.4")<br/>    cpu_request             = optional(string, "1")<br/>    memory_request          = optional(string, "1Gi")<br/>    memory_limit            = optional(string, "1Gi")<br/>    in_place_rollout        = optional(bool, true)<br/>    request_rollout         = optional(string, "00000000-0000-0000-0000-000000000000")<br/>    force_rollout           = optional(string, "00000000-0000-0000-0000-000000000000")<br/>    balancer_memory_request = optional(string, "256Mi")<br/>    balancer_memory_limit   = optional(string, "256Mi")<br/>    balancer_cpu_request    = optional(string, "100m")<br/>  }))</pre> | `[]` | no |
+| <a name="input_install_openebs"></a> [install\_openebs](#input\_install\_openebs) | Whether to install OpenEBS for NVMe storage | `bool` | `false` | no |
+| <a name="input_instances"></a> [instances](#input\_instances) | Configuration for Materialize instances | <pre>list(object({<br/>    name                    = string<br/>    namespace               = optional(string)<br/>    create_database         = optional(bool, true)<br/>    database_name           = string<br/>    metadata_backend_url    = string<br/>    persist_backend_url     = string<br/>    environmentd_version    = optional(string, "v0.130.4")<br/>    cpu_request             = optional(string, "1")<br/>    memory_request          = optional(string, "1Gi")<br/>    memory_limit            = optional(string, "1Gi")<br/>    in_place_rollout        = optional(bool, true)<br/>    request_rollout         = optional(string, "00000000-0000-0000-0000-000000000001")<br/>    force_rollout           = optional(string, "00000000-0000-0000-0000-000000000001")<br/>    balancer_memory_request = optional(string, "256Mi")<br/>    balancer_memory_limit   = optional(string, "256Mi")<br/>    balancer_cpu_request    = optional(string, "100m")<br/>  }))</pre> | `[]` | no |
 | <a name="input_metrics_server_version"></a> [metrics\_server\_version](#input\_metrics\_server\_version) | Version of metrics-server to install | `string` | `"3.12.2"` | no |
 | <a name="input_monitoring_namespace"></a> [monitoring\_namespace](#input\_monitoring\_namespace) | Namespace for monitoring resources | `string` | `"monitoring"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace prefix for all resources | `string` | n/a | yes |
+| <a name="input_openebs_namespace"></a> [openebs\_namespace](#input\_openebs\_namespace) | Namespace for OpenEBS components | `string` | `"openebs"` | no |
+| <a name="input_openebs_version"></a> [openebs\_version](#input\_openebs\_version) | Version of OpenEBS Helm chart to install | `string` | `"4.2.0"` | no |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | Namespace for the Materialize operator | `string` | `"materialize"` | no |
 | <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v25.1.2"` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | Postgres version to use for the metadata backend | `string` | `"15"` | no |
@@ -82,7 +88,10 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_materialize_instance_resource_ids"></a> [materialize\_instance\_resource\_ids](#output\_materialize\_instance\_resource\_ids) | Resource IDs of created Materialize instances |
 | <a name="output_materialize_instances"></a> [materialize\_instances](#output\_materialize\_instances) | Details of created Materialize instances |
+| <a name="output_openebs_enabled"></a> [openebs\_enabled](#output\_openebs\_enabled) | Whether OpenEBS is enabled |
+| <a name="output_openebs_namespace"></a> [openebs\_namespace](#output\_openebs\_namespace) | Namespace where OpenEBS is installed |
 | <a name="output_operator_namespace"></a> [operator\_namespace](#output\_operator\_namespace) | Namespace where the operator is installed |
 | <a name="output_operator_release_name"></a> [operator\_release\_name](#output\_operator\_release\_name) | Helm release name of the operator |
 | <a name="output_operator_release_status"></a> [operator\_release\_status](#output\_operator\_release\_status) | Status of the helm release |

--- a/main.tf
+++ b/main.tf
@@ -238,7 +238,7 @@ resource "helm_release" "openebs" {
 
   name       = "openebs"
   namespace  = kubernetes_namespace.openebs[0].metadata[0].name
-  repository = "https://openebs.github.io/charts"
+  repository = "https://openebs.github.io/openebs"
   chart      = "openebs"
   version    = var.openebs_version
 

--- a/main.tf
+++ b/main.tf
@@ -223,3 +223,29 @@ resource "helm_release" "metrics_server" {
 
   depends_on = [kubernetes_namespace.monitoring]
 }
+
+# Install OpenEBS for lgalloc support
+resource "kubernetes_namespace" "openebs" {
+  count = var.install_openebs ? 1 : 0
+
+  metadata {
+    name = var.openebs_namespace
+  }
+}
+
+resource "helm_release" "openebs" {
+  count = var.install_openebs ? 1 : 0
+
+  name       = "openebs"
+  namespace  = kubernetes_namespace.openebs[0].metadata[0].name
+  repository = "https://openebs.github.io/charts"
+  chart      = "openebs"
+  version    = var.openebs_version
+
+  set {
+    name  = "engines.replicated.mayastor.enabled"
+    value = "false"
+  }
+
+  depends_on = [kubernetes_namespace.openebs]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,3 +29,13 @@ output "materialize_instance_resource_ids" {
     for name, instance in data.kubernetes_resource.materialize_instances : name => instance.object.status.resourceId
   }
 }
+
+output "openebs_enabled" {
+  description = "Whether OpenEBS is enabled"
+  value       = var.install_openebs
+}
+
+output "openebs_namespace" {
+  description = "Namespace where OpenEBS is installed"
+  value       = var.install_openebs ? var.openebs_namespace : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,7 @@ variable "operator_namespace" {
   default     = "materialize"
 }
 
+# Monitoring configuration
 variable "monitoring_namespace" {
   description = "Namespace for monitoring resources"
   type        = string
@@ -61,6 +62,26 @@ variable "install_metrics_server" {
   default     = true
 }
 
+# OpenEBS configuration
+variable "install_openebs" {
+  description = "Whether to install OpenEBS for NVMe storage"
+  type        = bool
+  default     = false
+}
+
+variable "openebs_namespace" {
+  description = "Namespace for OpenEBS components"
+  type        = string
+  default     = "openebs"
+}
+
+variable "openebs_version" {
+  description = "Version of OpenEBS Helm chart to install"
+  type        = string
+  default     = "4.2.0"
+}
+
+# Materialize instance configuration
 variable "instances" {
   description = "Configuration for Materialize instances"
   type = list(object({


### PR DESCRIPTION
As part of: https://github.com/MaterializeInc/materialize/pull/31796

Here we will handle the OpenEBS installation, that way this can be reused in all other Cloud providers.

I am still not sure if the NVMe daemonset is better suited in the Helm module or in the cloud specific Terraform modules. Feels like it belongs to the individual cloud TF modules, but open to suggestions.