### PR TITLE
Do not override orchestratord version by default.

### DIFF
--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -6,9 +6,9 @@ locals {
       }
     }
     operator = {
-      image = {
+      image = var.orchestratord_version == null ? {} : {
         tag = var.orchestratord_version
-      }
+      },
       cloudProvider = {
         type   = "aws"
         region = data.aws_region.current.name

--- a/examples/aws/variables.tf
+++ b/examples/aws/variables.tf
@@ -41,7 +41,7 @@ variable "helm_values" {
 variable "orchestratord_version" {
   description = "Version of the Materialize orchestrator to install"
   type        = string
-  default     = "v0.138.0"
+  default     = null
 }
 
 variable "operator_namespace" {

--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -50,9 +50,9 @@ module "operator" {
   operator_namespace = var.operator_namespace
 
   helm_values = {
-    image = {
+    image = var.orchestratord_version == null ? {} : {
       tag = var.orchestratord_version
-    }
+    },
     observability = {
       podMetrics = {
         enabled = true

--- a/examples/gcp/variables.tf
+++ b/examples/gcp/variables.tf
@@ -19,7 +19,7 @@ variable "region" {
 variable "orchestratord_version" {
   description = "Version of the Materialize orchestrator to install"
   type        = string
-  default     = "v0.138.0"
+  default     = null
 }
 
 variable "instance_configs" {


### PR DESCRIPTION
Do not override orchestratord version by default.

The helm chart includes the orchestratord version, and people should probably just use the default in 99% of cases. We also don't want to have to keep updating these examples every time the version changes.