### PR TITLE
Update chart to v25.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ No modules.
 | <a name="input_monitoring_namespace"></a> [monitoring\_namespace](#input\_monitoring\_namespace) | Namespace for monitoring resources | `string` | `"monitoring"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace prefix for all resources | `string` | n/a | yes |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | Namespace for the Materialize operator | `string` | `"materialize"` | no |
-| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v25.1.6"` | no |
+| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | Version of the Materialize operator to install | `string` | `"v25.1.7"` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | Postgres version to use for the metadata backend | `string` | `"15"` | no |
 | <a name="input_use_local_chart"></a> [use\_local\_chart](#input\_use\_local\_chart) | Whether to use a local chart instead of one from a repository | `bool` | `false` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "environment" {
 variable "operator_version" {
   description = "Version of the Materialize operator to install"
   type        = string
-  default     = "v25.1.6"
+  default     = "v25.1.7"
   nullable    = false
 }
 


### PR DESCRIPTION
Verified the versions on a local kind cluster
```
Containers:
  materialize-operator:
    Container ID:  containerd://571f1b11215ff1fb86a7eea406aa172a994f2cb5de94808698c1b465d4b4d94d
    Image:         materialize/orchestratord:v0.138.0
    Image ID:      docker.io/materialize/orchestratord@sha256:116bd0471c109c3a85199bf4ef47911c4246e64b08451a2f8d81756a0e3079de
    Port:          <none>
    Host Port:     <none>
    Args:
      --helm-chart-version=v25.1.7
```